### PR TITLE
Restore missing "friendly" check in PlayerUse

### DIFF
--- a/lua/apartments/cl_apartments.lua
+++ b/lua/apartments/cl_apartments.lua
@@ -94,6 +94,7 @@ local function receive_rent_change(ply_sid64, room_n, change)
 		local room = Apartments.List[room_n]
 		room.tenant = nil
 		room.public = false
+		room.friendly = false
 		room.invitees = {}
 	end
 end

--- a/lua/apartments/sv_apartments.lua
+++ b/lua/apartments/sv_apartments.lua
@@ -441,7 +441,7 @@ hook.Add("PlayerUse", tag, function(ply, ent)
 	if not room.tenant then return end
 
 	local tenant = get_by_sid64(room.tenant)
-	if tenant == ply or ply.Unrestricted or room.public or room.invitees[ply:SteamID64()] then return end
+	if tenant == ply or ply.Unrestricted or room.public or room.invitees[ply:SteamID64()] or (room.friendly and tenant and tenant.IsFriend and tenant:IsFriend(ply)) then return end
 
 	if not last_knocked[ply] then last_knocked[ply] = CurTime() - 20 end
 	if last_knocked[ply] + 20 > CurTime() then return false end


### PR DESCRIPTION
Restore "friendly" check in PlayerUse; https://github.com/Metastruct/ms_apartments/commit/ce485ef9ad273d73ff5a159acd9e5e3e44d7d9fe#diff-6d67757237319e28f34adfce32e62340b18e276ddbe0fe1af41749915db3e27eL438
Clear "friendly" bool on client when abandon apartment.