### PR TITLE
catch a race condition

### DIFF
--- a/lua/apartments/cl_apartments.lua
+++ b/lua/apartments/cl_apartments.lua
@@ -224,7 +224,7 @@ net.Receive(tag, function()
 
 		is_client_renting = false
 		local lp = LocalPlayer()
-		local my_id64 = IsValid(lp) and lp:SteamID64() or nil
+		local my_id64 = lp and lp.SteamID64 and lp:SteamID64()
 		if my_id64 then
 			for room_number, room in pairs(rooms) do
 				if room.tenant == my_id64 then

--- a/lua/apartments/cl_apartments.lua
+++ b/lua/apartments/cl_apartments.lua
@@ -223,9 +223,13 @@ net.Receive(tag, function()
 		rooms = util.JSONToTable(util.Decompress(net.ReadData(payload_size)))
 
 		is_client_renting = false
-		for room_number, room in pairs(rooms) do
-			if room.tenant == LocalPlayer():SteamID64() then
-				is_client_renting = room_number
+		local lp = LocalPlayer()
+		local my_id64 = IsValid(lp) and lp:SteamID64() or nil
+		if my_id64 then
+			for room_number, room in pairs(rooms) do
+				if room.tenant == my_id64 then
+					is_client_renting = room_number
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Sometimes the steamid is grabbed before localplayer is ready, this should fix it.

Player ERR: [NET] ms_apartments: lua/apartments/cl_apartments.lua:227: attempt to call method 'SteamID64' (a nil value) stack traceback:
	lua/apartments/cl_apartments.lua:227: in function <lua/apartments/cl_apartments.lua:218>
	[C]: in function 'xpcall'
	lua/includes/extensions/net.lua:191: in function <lua/includes/extensions/net.lua:146>